### PR TITLE
OpenTofu Specific Code Override: Add support to .tofu files

### DIFF
--- a/internal_configs_testdata_tofu-and-tf-files_resources.tf
+++ b/internal_configs_testdata_tofu-and-tf-files_resources.tf
@@ -1,0 +1,43 @@
+resource "aws_security_group" "firewall_tofu" {
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy = true
+    ignore_changes = [
+      description,
+    ]
+  }
+
+  connection {
+    host = "127.0.0.1"
+  }
+
+  provisioner "local-exec" {
+    command = "echo hello"
+
+    connection {
+      host = "10.1.2.1"
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "echo hello"
+  }
+}
+
+resource "aws_instance" "web_tofu" {
+  count = 2
+  ami = "ami-1234"
+  security_groups = [
+    "foo",
+    "bar",
+  ]
+
+  network_interface {
+    device_index = 0
+    description = "Main network interface"
+  }
+
+  depends_on = [
+    aws_security_group.firewall,
+  ]
+}


### PR DESCRIPTION
As decided by the [RFC: OpenTofu Specific Code Override #1699](https://github.com/opentofu/opentofu/pull/1699), this PR allows OpenTofu to read `.tofu` files.

The `.tofu` files replace the `.tf` files with the same name. In this PR, we addressed the following scenarios:
1. If a `.tofu` file exists, we’ll load it instead of the `.tf` file.
2. For [JSON Configuration](https://opentofu.org/docs/language/syntax/json/), if a `.tofu.json` file exists, we’ll load it instead of the `tf.json` file. 
3. For [test files](https://opentofu.org/docs/cli/commands/test/), if `.tofutest.hcl`/`.tofutest.json` files exist, we’ll load them instead of the `.tftest.hcl`/`.tftest.json` files. 
4. For [override files](https://opentofu.org/docs/language/files/override/), if `_override.tofu`/`_override.tofu.json` files exist, we’ll load them instead of the `_override.tf`/`_override.tf.json` files. To further clarify, if a `main.tofu` file exists with the override file `main_override.tf`, we’ll load them both (unless `main_override.tofu` exists, and then we'll load it instead of `main_override.tf`).

We'll address `.tfvars` and `.tfvars.json` in a different PR.


<!-- If your PR resolves an issue, please add it here. -->
Part of RFC: OpenTofu Specific Code Override #1699

## Target Release

1.8.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
